### PR TITLE
fix: add "this: void" to methods on interfaces

### DIFF
--- a/api/createPipe.ts
+++ b/api/createPipe.ts
@@ -2,14 +2,14 @@ import { Signal, Sink, Source, Talkback } from "strict-callbag"
 import { subscribe, Subscription } from "./subscribe"
 
 interface Callbacks<A, EI, EO> {
-  onStart: (sub: Subscription) => void
-  onData: (sub: Subscription, data: A) => void
-  onEnd: (err?: EI) => void
+  onStart: (this: void, sub: Subscription) => void
+  onData: (this: void, sub: Subscription, data: A) => void
+  onEnd: (this: void, err?: EI) => void
 
-  onRequest: (sub: Subscription) => void
-  onAbort: (err?: EO) => void
+  onRequest: (this: void, sub: Subscription) => void
+  onAbort: (this: void, err?: EO) => void
 
-  talkbackOverride?: (original: Talkback<any>) => Talkback<any>
+  talkbackOverride?: (this: void, original: Talkback<any>) => Talkback<any>
 }
 
 /**

--- a/api/emitter.ts
+++ b/api/emitter.ts
@@ -1,9 +1,9 @@
 import { Signal, Sink } from "strict-callbag"
 
 export interface Emitter<A, E> {
-  data(a: A): void
-  error(e: E): void
-  end(): void
+  data(this: void, a: A): void
+  error(this: void, e: E): void
+  end(this: void): void
 }
 
 export const emitter = <A, E>(sink: Sink<A, E>): Emitter<A, E> => ({

--- a/api/subscribe.ts
+++ b/api/subscribe.ts
@@ -1,9 +1,9 @@
 import { Signal, Source, Talkback } from "strict-callbag"
 
 interface Callbacks<A, E> {
-  onStart: () => void
-  onData: (data: A) => void
-  onEnd: (err?: E) => void
+  onStart: (this: void) => void
+  onData: (this: void, data: A) => void
+  onEnd: (this: void, err?: E) => void
 
   talkbackOverride?: (original: Talkback<any>) => Talkback<any>
 }


### PR DESCRIPTION
This will prevent "@typescript-eslint/unbound-method" form flagging the functions