### PR TITLE
Fix createPipe.ts TS2872

### DIFF
--- a/api/createPipe.ts
+++ b/api/createPipe.ts
@@ -56,7 +56,7 @@ export const createPipe = <A, EI, EO = never>(
       } else {
         onRequest(sub)
       }
-    } else if (2) {
+    } else if (signal === 2) {
       sub?.cancel()
       onAbort(err)
     }


### PR DESCRIPTION
Fixes:
```

../../node_modules/strict-callbag-basics/api/createPipe.ts:59:16 - error TS2872: This kind of expression is always truthy.

59     } else if (2) {
                  ~


Found 1 error.

```